### PR TITLE
Fixed app.listen - removed localhost host

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@ const app = require("./app");
 
 // App Listener setup
 const port = process.env.PORT;
-const hostname = "localhost" || "127.0.0.1";
 
-app.listen(port, hostname, () => {
-    console.log(`Server is up on port ${port} : http://${hostname}:${port}/`);
+app.listen(port, () => {
+    console.log(`Server is up on port ${port}`);
 });


### PR DESCRIPTION
Hostname variable was interrupting deployed website because hostname variable was set to "localhost" || "127.0.0.1"
-removed hostname variable in the app.listen param